### PR TITLE
docs: rewrite README structure and usage guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
-# ft_containers
- Re-implementation of C++ containers : Vector, Stack, and Map 
+# FT_CONTAINERS
+
+A C++98 re-implementation of three standard containers:
+- `ft::vector`
+- `ft::stack`
+- `ft::map`
+
+## What I gained from the project
+
+Working on this project helped me build practical knowledge of:
+- implementing container internals with templates in C++98
+- iterator behavior and compatibility with generic algorithms
+- memory management patterns and exception-safe container operations
+- binary tree-based associative container logic for `map`
+- reproducing STL-like APIs and testing behavior against `std`
+
+## Prerequisites
+
+- A C++ compiler compatible with C++98 (`c++`/`clang++`/`g++`)
+- `make`
+- A Unix-like environment (Linux/macOS)
+
+The project is compiled with these flags:
+- `-Wall -Wextra -Werror -std=c++98`
+
+## Usage
+
+Build the executable:
+
+```bash
+make
+```
+
+Run the main test program (requires a seed argument):
+
+```bash
+./containers 42
+```
+
+Useful make targets:
+
+```bash
+make run      # build + run
+make clean    # remove object files
+make fclean   # remove object files + executable
+make re       # rebuild from scratch
+```
+
+If you want to compare behavior with the standard library vs your own implementation,
+update the `#if` switch in `main.cpp`.


### PR DESCRIPTION
### Motivation

- Restructure the repository `README.md` to match the requested layout with the headings `# FT_CONTAINERS`, `## What I gained from the project`, `## Prerequisites`, and `## Usage`.
- Provide a clearer project overview and concise developer-facing instructions so contributors can build and run the tests quickly.

### Description

- Rewrote `README.md` to include a short project summary and to list implemented containers (`ft::vector`, `ft::stack`, `ft::map`).
- Added a `## What I gained from the project` section describing learning outcomes around templates, iterators, memory management, and associative container logic.
- Added a `## Prerequisites` section listing required tools and the compile flags used (`-Wall -Wextra -Werror -std=c++98`).
- Added a `## Usage` section with build/run instructions and useful `make` targets (`make`, `make run`, `make clean`, `make fclean`, `make re`).

### Testing

- Ran `make` in the project root and the build completed successfully.
- Ran `make fclean` to verify cleanup and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992fe6b6280832e95b7a8912370cb19)